### PR TITLE
Fix Bug 279079: WebDriver cookies failing to store

### DIFF
--- a/LayoutTests/http/tests/webdriver/cookie-storage-webdriver-279079-expected.txt
+++ b/LayoutTests/http/tests/webdriver/cookie-storage-webdriver-279079-expected.txt
@@ -1,0 +1,11 @@
+Tests that WebDriver cookie storage infrastructure is working properly (Bug 279079)
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.cookie is ""
+PASS document.cookie is "jsCookie=testValue"
+PASS document.cookie is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE 

--- a/LayoutTests/http/tests/webdriver/cookie-storage-webdriver-279079.html
+++ b/LayoutTests/http/tests/webdriver/cookie-storage-webdriver-279079.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../cookies/resources/cookies-test-pre.js"></script>
+</head>
+<body>
+<script>
+description('Tests that WebDriver cookie storage infrastructure is working properly (Bug 279079)');
+
+clearAllCookies();
+
+shouldBeEqualToString("document.cookie", "");
+
+// Test that JavaScript cookie setting works (this always worked)
+document.cookie = "jsCookie=testValue; path=/";
+
+shouldBeEqualToString("document.cookie", "jsCookie=testValue");
+
+// Clear the cookie
+document.cookie = "jsCookie=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+
+shouldBeEqualToString("document.cookie", "");
+
+// Note: The actual WebDriver cookie setting is tested in the WebDriver test suite
+// This layout test just verifies that the cookie infrastructure is working
+
+clearCookies();
+</script>
+<script src="../cookies/resources/cookies-test-post.js"></script>
+</body>
+</html> 

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -134,8 +134,22 @@ void WebCookieManager::getCookies(PAL::SessionID sessionID, const URL& url, Comp
 void WebCookieManager::setCookie(PAL::SessionID sessionID, const Vector<Cookie>& cookies, uint64_t cookiesVersion, CompletionHandler<void()>&& completionHandler)
 {
     if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID)) {
-        for (auto& cookie : cookies)
-            storageSession->setCookie(cookie);
+        // Use setCookies with URL context when possible to ensure proper cookie storage
+        // This fixes Bug 279079 where WebDriver cookies weren't being stored properly
+        for (auto& cookie : cookies) {
+            // Construct a URL from the cookie domain to provide context for proper cookie storage
+            URL cookieURL;
+            if (!cookie.domain.isEmpty()) {
+                String scheme = cookie.secure ? "https"_s : "http"_s;
+                cookieURL = URL(scheme + "://"_s + cookie.domain + "/"_s);
+            } else {
+                // Fallback to a default URL if no domain is specified
+                cookieURL = URL("http://localhost/"_s);
+            }
+
+            // Use setCookies with URL context to ensure proper libsoup API usage
+            storageSession->setCookies({ cookie }, cookieURL, cookieURL);
+        }
         storageSession->setCookiesVersion(cookiesVersion);
     } else
         RELEASE_LOG_ERROR(Storage, "%p - WebCookieManager::setCookie failed to set cookies and version (%" PRIu64 ") for session %" PRIu64, this, cookiesVersion, sessionID.toUInt64());


### PR DESCRIPTION
#### b432bececebee3bda41026bb6f605ec7574f5f62
<pre>
Fix Bug 279079: WebDriver cookies failing to store

WebDriver cookie setting was failing because it used the wrong libsoup API.
The setCookie function used soup_cookie_jar_add_cookie() which doesn&apos;t emit
the &apos;changed&apos; signal, while setCookieFromDOM used soup_cookie_jar_add_cookie_full()
which properly emits the signal.

Fixed by modifying WebCookieManager::setCookie() to use storageSession-&gt;setCookies()
with URL context instead of storageSession-&gt;setCookie() for each cookie individually.
This ensures WebDriver cookies use the same libsoup API as JavaScript cookies.

Added a layout test to verify the cookie storage infrastructure is working properly.

https://bugs.webkit.org/show_bug.cgi?id=279079
</pre>